### PR TITLE
Fix link to timepulse.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ TimePulse provides callback endpoints for both GitHub and PivotalTracker. If the
 
 ## Documentation
 
-Documentation and examples can be found at [timepulse.io](http://timepulse.io, "TimePulse Home Page").  (Not yet up as of 11/4/2013)
+Documentation and examples can be found at [timepulse.io](http://timepulse.io "TimePulse Home Page").
 
 ## Getting Started
 


### PR DESCRIPTION
Remove a comma that makes the link to timepulse.io doesn't work. Also, remove the note "Not yet up as of 11/4/2013" as the site is up, so, you know :)

Great work btw
