### PR TITLE
Adding Ninja.suppressChangeEvents() to .selectbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ db_backups/
 errors.err
 .rspec-local
 .ctrlp-root
+apache-passenger.conf

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -52,6 +52,7 @@ Ninja.behavior({
     '.fix_work_unit_button': Ninja.submitsAsAjax(),
     '*[data-remote=true]': Ninja.submitsAsAjax(),
     '#debug':        Ninja.suppressChangeEvents(),
+    '.selectboxit':  Ninja.suppressChangeEvents(),
     '#task_elapsed':  Ninja.suppressChangeEvents(),
     '.date_entry': { transform: function(elem){ $(elem).datepicker() }},
     '.datetime_entry': {


### PR DESCRIPTION
The problem with speed on selectboxes is that they created a TON of change
events, and NS bogged down there. C'est la vie, I suppose.
