### PR TITLE
The devise mailer now receives one extra token argument on each method (...

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token) %></p>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. You are now signed in."
+      confirmed: "Your account was successfully confirmed."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:


### PR DESCRIPTION
...since Devise 3.1).  Updated confirmation view to not get the token directly from the resource itself.  It is also possible for a user not to be logged in after confirming, made changes to text to reflect this
