### PR TITLE
Adds rake activities:associate_orphans and the underlying OrphanActivityAssociator

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,9 +1,23 @@
 require 'bcrypt'
 class ActivitiesController < ApplicationController
+  include WorkUnitsHelper
   before_action :restrict_access, only: [:create]
 
   def create
+    @user = User.where(:login => request.headers["login"]).first
+    @current_work_unit = @user.work_units.where(:stop_time => nil).last
     @activity = Activity.new(activity_params)
+    p @current_work_unit.id
+    #check to see if the user making the request has an open work unit
+    if @current_work_unit
+      p "there is an open work unit"
+      if @current_work_unit.project_id == @activity.project_id
+        p "project_id is equal"
+        @activity.work_unit_id = @current_work_unit.id
+        p @activity.work_unit_id
+      end
+    end
+
       if @activity.save
         render json: @activity, status: 201
       else
@@ -14,16 +28,16 @@ class ActivitiesController < ApplicationController
 private
 
   def activity_params
-    params.require(:activity).permit(:description, :project_id, :source, :time, :action, :user_id, properties: [:story_id])
+    params.require(:activity).permit(:description, :work_unit_id, :project_id, :source, :time, :action, :user_id, properties: [:story_id])
   end
 
   def restrict_access
-    user = User.where(:login => request.headers["login"]).first
-    unless user = User.where(:login => request.headers["login"]).first
+    @user = User.where(:login => request.headers["login"]).first
+    unless @user = User.where(:login => request.headers["login"]).first
       render json: "authorization failed no user" , status: 403
     end
     utoken = request.headers["Authorization"]
-    if BCrypt::Password.new(user.encrypted_token) == utoken
+    if BCrypt::Password.new(@user.encrypted_token) == utoken
       return true
     else
       render json: "authorization failed wrong token", status: 403

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,16 +1,14 @@
 require 'bcrypt'
 class ActivitiesController < ApplicationController
-  include WorkUnitsHelper
+  # include WorkUnitsHelper
   before_action :restrict_access, only: [:create]
 
   def create
     @user = User.where(:login => request.headers["login"]).first
     @current_work_unit = @user.work_units.where(:stop_time => nil).last
     @activity = Activity.new(activity_params)
-    p @current_work_unit.id
     #check to see if the user making the request has an open work unit
     if @current_work_unit
-      p "there is an open work unit"
       if @current_work_unit.project_id == @activity.project_id
         p "project_id is equal"
         @activity.work_unit_id = @current_work_unit.id

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -13,6 +13,8 @@ class Activity < ActiveRecord::Base
 
   scope :story_changes, lambda { where("defined(properties, ?)", "current_state") }
 
+  scope :orphan, lambda { where(:work_unit_id => nil) }
+
   #TODO Fix these - it may involve using STI so we have actual classes for each
   #activity type
   def story_id

--- a/app/models/work_unit.rb
+++ b/app/models/work_unit.rb
@@ -61,6 +61,7 @@ class WorkUnit < ActiveRecord::Base
   belongs_to :project
   belongs_to :invoice
   belongs_to :bill
+  has_many :activities
 
   validates_presence_of :project_id
   validates_presence_of :user_id

--- a/db/migrate/20150601232952_add_work_unit_to_activities.rb
+++ b/db/migrate/20150601232952_add_work_unit_to_activities.rb
@@ -1,0 +1,5 @@
+class AddWorkUnitToActivities < ActiveRecord::Migration
+  def change
+    add_reference :activities, :work_unit, index: true
+  end
+end

--- a/lib/orphan_activity_associator.rb
+++ b/lib/orphan_activity_associator.rb
@@ -1,0 +1,17 @@
+class OrphanActivityAssociator
+  def initialize(earliest_time)
+    @time_from = earliest_time
+  end
+  attr_reader :time_from
+
+  def run
+    Activity.orphan.where("time > ?", time_from).each do |activity|
+      work_units = WorkUnit.where(:user_id => activity.user_id,
+                                  :project_id => activity.project_id).where(
+                                    "start_time < ? AND ? < stop_time",
+                                    activity.time + 15.minutes, activity.time - 15.minutes)
+      activity.work_unit = work_units.first
+      activity.save!
+    end
+  end
+end

--- a/lib/tasks/activities.rake
+++ b/lib/tasks/activities.rake
@@ -1,0 +1,6 @@
+namespace :activities do
+  desc "Attempts to find associated work units for activities recorded in the prior 24 hours"
+  task :associate_orphans do
+    OrphanActivityAssociator.new(Time.now - 24.hours).run
+  end
+end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,94 +1,94 @@
-  require 'spec_helper'
+require 'spec_helper'
 
-  describe ActivitiesController do
+describe ActivitiesController do
 
-    let :activity_attrs do
-     FactoryGirl.attributes_for(:activity, :project => @project, :user => @user)
-   end
-    before(:each) do
-      @base_time = Time.now.beginning_of_day-1.day+12.hours
-      @user = FactoryGirl.create(:user)
-      @user2 = FactoryGirl.create(:user)
-      @project = FactoryGirl.create(:project)
-      @project_different = FactoryGirl.create(:project)
-      #create activity and work_unit that both have the same project associated
+  let :activity_attrs do
+    FactoryGirl.attributes_for(:activity, :project => @project, :user => @user)
+  end
+  before(:each) do
+    @base_time = Time.now.beginning_of_day-1.day+12.hours
+    @user = FactoryGirl.create(:user)
+    @user2 = FactoryGirl.create(:user)
+    @project = FactoryGirl.create(:project)
+    @project_different = FactoryGirl.create(:project)
+    #create activity and work_unit that both have the same project associated
 
-      @current_work_unit = FactoryGirl.create(:work_unit, :project => @project,
-        :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil,
-         :notes => "Work Unit, Clocked in")
-      @non_current_work_unit = FactoryGirl.create(:work_unit, :project => @project,
-        :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1,
-        :user => @user, :notes => "Work Unit, Not Clocked in")
-      #work unit for a user who is not clocked in
-      @closed_work_unit = FactoryGirl.create(:work_unit, :project => @project,
-        :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1,
-         :user => @user2, :notes => "Work Unit, Not Clocked in")
-      #create activity and work_unit with different projects associated
-      activity_different_attrs = FactoryGirl.attributes_for(:activity, :project =>
-        @project_different, :user => @user)
-      @activity_different_request = {activity: {description:
-        activity_different_attrs[:description], project_id: activity_different_attrs[:project_id],
-         source: activity_different_attrs[:source], time: @base_time, user_id: @user.id}}
-      @activity_request = {activity: {description: activity_attrs[:description],
-        project_id: @project.id, source: activity_attrs[:source], time: @base_time,
-        user_id: @user.id}}
+    @current_work_unit = FactoryGirl.create(:work_unit, :project => @project,
+                                            :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil,
+                                            :notes => "Work Unit, Clocked in")
+
+    @non_current_work_unit = FactoryGirl.create(:work_unit, :project => @project,
+                                                :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1,
+                                                :user => @user, :notes => "Work Unit, Not Clocked in")
+
+    #work unit for a user who is not clocked in
+    @closed_work_unit = FactoryGirl.create(:work_unit, :project => @project,
+                                           :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1,
+                                           :user => @user2, :notes => "Work Unit, Not Clocked in")
+
+    #create activity and work_unit with different projects associated
+    activity_different_attrs = FactoryGirl.attributes_for(:activity, :project =>
+                                                          @project_different, :user => @user)
+    @activity_different_request = {activity: {description:
+                                              activity_different_attrs[:description], project_id: activity_different_attrs[:project_id],
+                                              source: activity_different_attrs[:source], time: @base_time}}
+    @activity_request = {
+      activity: {
+        description: activity_attrs[:description],
+        project_id: @project.id,
+        source: activity_attrs[:source],
+        time: @base_time
+      }}
+  end
+
+  describe "hit endpoint with a post request that saves activity" do
+    it "should respond with a 201 status" do
+      request.headers["accept"] = 'application/json'
+      request.headers["Content-Type"] = 'application/json'
+      request.headers["login"] = @user.login
+      request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
+      post :create, @activity_request
+
+      expect(response.status).to eq(201)
     end
 
-    describe "hit endpoint with a post request that saves activity" do
-      it "should respond with a 201 status" do
+    it "should create a new activity in the database" do
+      expect do
         request.headers["accept"] = 'application/json'
         request.headers["Content-Type"] = 'application/json'
         request.headers["login"] = @user.login
         request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
-        p @activity_request
         post :create, @activity_request
-
-        expect(response.status).to eq(201)
-      end
-
-      it "should create a new activity in the database" do
-        expect do
-          request.headers["accept"] = 'application/json'
-          request.headers["Content-Type"] = 'application/json'
-          request.headers["login"] = @user.login
-          request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
-          post :create, @activity_request
-        end.to change{
-            Activity.where(description: activity_attrs[:description]).count
-            }.from(0).to(1)
-      end
-    end
-
-    #all above tests are passing and working as expected.
-
-    describe "make a new activity and associate it with the current work unit, if clocked_in" do
-      before(:each) do
-        request.headers["accept"] = 'application/json'
-        request.headers["Content-Type"] = 'application/json'
-        request.headers["login"] = @user.login
-        request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
-      end
-      it "assigns the current work unit id to the new activity" do
-        post :create, @activity_request
-        expect(assigns(:activity).work_unit_id).to eq(@current_work_unit.id)
-      end
-      it "confirms current_work_unit and activity_different don't have to same project associated"do
-        post :create, @activity_different_request
-        expect(assigns(:activity).work_unit_id).to eq(nil)
-      end
-      it "confirms that work units that have a stop time aren't associated to the activity" do
-        @activity_request[:activity][:user_id] = @user2.id
-        p @activity_request
-        post :create, @activity_request
-        expect(assigns(:activity).work_unit_id).to eq(nil)
-
-      end
-    end
-
-    describe "make a new activity that is an orphan from work units, if not clocked in" do
-      it "checks to see if the user is clocked in" do
-        # expect(@user.clocked_in?).to be false
-      end
-
+      end.to change{
+        Activity.where(description: activity_attrs[:description]).count
+      }.from(0).to(1)
     end
   end
+
+  #all above tests are passing and working as expected.
+
+  describe "make a new activity and associate it with the current work unit, if clocked_in" do
+    before(:each) do
+      request.headers["accept"] = 'application/json'
+      request.headers["Content-Type"] = 'application/json'
+      request.headers["login"] = @user.login
+      request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
+    end
+
+    it "assigns the current work unit id to the new activity" do
+      post :create, @activity_request
+      expect(assigns(:activity).work_unit_id).to eq(@current_work_unit.id)
+    end
+
+    it "confirms current_work_unit and activity_different don't have to same project associated"do
+      post :create, @activity_different_request
+      expect(assigns(:activity).work_unit_id).to eq(nil)
+    end
+
+    it "confirms that work units that have a stop time aren't associated to the activity" do
+      request.headers["login"] = @user2.login
+      post :create, @activity_request
+      expect(assigns(:activity).work_unit_id).to eq(nil)
+    end
+  end
+end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -10,6 +10,7 @@
       #create activity and work_unit that both have the same project associated
       @activity = FactoryGirl.create(:activity, :project => @project, :user => @user)
       @current_work_unit = FactoryGirl.create(:work_unit, :project => @project, :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil, :notes => "Work Unit, Clocked in")
+      @non_current_work_unit = FactoryGirl.create(:work_unit, :project => @project, :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1, :user => @user, :notes => "Work Unit, Not Clocked in")
       #create activity and work_unit with different projects associated
       @activity_different = FactoryGirl.create(:activity, :project => @project_different, :user => @user)
       @activity_request = {activity: {description: @activity.description, project_id: @activity.project_id, source: @activity.source, time: @base_time, user_id: @user.id}}
@@ -48,6 +49,10 @@
       it "confirms current_work_unit and activity_different don't have to same project associated"do
         expect(@current_work_unit.project_id).not_to eq(@activity_different.project_id)
       end
-
+      it "confirms that work units that have a stop time aren't associated to the activity" do
+        p @activity.work_unit_id
+        p @activity_different.work_unit_id
+        expect(@activity.work_unit_id).not_to eq(@non_current_work_unit.project_id)
+      end
     end
   end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -6,9 +6,13 @@
       @base_time = Time.now.beginning_of_day-1.day+12.hours
       @user = FactoryGirl.create(:user)
       @project = FactoryGirl.create(:project)
+      @project_different = FactoryGirl.create(:project)
       #create activity and work_unit that both have the same project associated
-      @activity = FactoryGirl.create(:activity, :project => @project)
+      @activity = FactoryGirl.create(:activity, :project => @project, :user => @user)
       @current_work_unit = FactoryGirl.create(:work_unit, :project => @project, :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil, :notes => "Work Unit, Clocked in")
+      #create activity and work_unit with different projects associated
+      @activity_different = FactoryGirl.create(:activity, :project => @project_different, :user => @user)
+      @activity_request = {activity: {description: @activity.description, project_id: @activity.project_id, source: @activity.source, time: @base_time, user_id: @user.id}}
     end
 
     describe "hit endpoint with a post request that saves activity" do
@@ -17,7 +21,7 @@
         request.headers["Content-Type"] = 'application/json'
         request.headers["login"] = @user.login
         request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
-        post :create, {activity: {description: "UPDATE AUTH TEST", project_id: 1  , source: "QWE"}}
+        post :create, @activity_request
         expect(response.status).to eq(201)
       end
 
@@ -27,10 +31,10 @@
           request.headers["Content-Type"] = 'application/json'
           request.headers["login"] = @user.login
           request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
-          post :create, {activity: {description: "UPDATE AUTH TEST", project_id: 1  , source: "QWE"}}
+          post :create, @activity_request
         end.to change{
-            Activity.where(description: "UPDATE AUTH TEST").count
-            }.from(0).to(1)
+            Activity.where(description: @activity.description).count
+            }.from(2).to(3)
       end
     end
 
@@ -40,6 +44,9 @@
       end
       it "confirms current_work_unit & activity request have the same project associated" do
         expect(@current_work_unit.project_id).to eq(@activity.project_id)
+      end
+      it "confirms current_work_unit and activity_different don't have to same project associated"do
+        expect(@current_work_unit.project_id).not_to eq(@activity_different.project_id)
       end
 
     end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -2,18 +2,36 @@
 
   describe ActivitiesController do
 
+    let :activity_attrs do
+     FactoryGirl.attributes_for(:activity, :project => @project, :user => @user)
+   end
     before(:each) do
       @base_time = Time.now.beginning_of_day-1.day+12.hours
       @user = FactoryGirl.create(:user)
+      @user2 = FactoryGirl.create(:user)
       @project = FactoryGirl.create(:project)
       @project_different = FactoryGirl.create(:project)
       #create activity and work_unit that both have the same project associated
-      @activity = FactoryGirl.create(:activity, :project => @project, :user => @user)
-      @current_work_unit = FactoryGirl.create(:work_unit, :project => @project, :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil, :notes => "Work Unit, Clocked in")
-      @non_current_work_unit = FactoryGirl.create(:work_unit, :project => @project, :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1, :user => @user, :notes => "Work Unit, Not Clocked in")
+
+      @current_work_unit = FactoryGirl.create(:work_unit, :project => @project,
+        :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil,
+         :notes => "Work Unit, Clocked in")
+      @non_current_work_unit = FactoryGirl.create(:work_unit, :project => @project,
+        :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1,
+        :user => @user, :notes => "Work Unit, Not Clocked in")
+      #work unit for a user who is not clocked in
+      @closed_work_unit = FactoryGirl.create(:work_unit, :project => @project,
+        :start_time => @base_time, :stop_time => @base_time+1.hours, :hours => 1,
+         :user => @user2, :notes => "Work Unit, Not Clocked in")
       #create activity and work_unit with different projects associated
-      @activity_different = FactoryGirl.create(:activity, :project => @project_different, :user => @user)
-      @activity_request = {activity: {description: @activity.description, project_id: @activity.project_id, source: @activity.source, time: @base_time, user_id: @user.id}}
+      activity_different_attrs = FactoryGirl.attributes_for(:activity, :project =>
+        @project_different, :user => @user)
+      @activity_different_request = {activity: {description:
+        activity_different_attrs[:description], project_id: activity_different_attrs[:project_id],
+         source: activity_different_attrs[:source], time: @base_time, user_id: @user.id}}
+      @activity_request = {activity: {description: activity_attrs[:description],
+        project_id: @project.id, source: activity_attrs[:source], time: @base_time,
+        user_id: @user.id}}
     end
 
     describe "hit endpoint with a post request that saves activity" do
@@ -22,7 +40,9 @@
         request.headers["Content-Type"] = 'application/json'
         request.headers["login"] = @user.login
         request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
+        p @activity_request
         post :create, @activity_request
+
         expect(response.status).to eq(201)
       end
 
@@ -34,25 +54,41 @@
           request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
           post :create, @activity_request
         end.to change{
-            Activity.where(description: @activity.description).count
-            }.from(2).to(3)
+            Activity.where(description: activity_attrs[:description]).count
+            }.from(0).to(1)
       end
     end
 
-    describe "make a new activity that is associated with the current work unit, if clocked_in" do
-      it "checks to see if the user is clocked in" do
-        expect(@user.clocked_in?).to be true
+    #all above tests are passing and working as expected.
+
+    describe "make a new activity and associate it with the current work unit, if clocked_in" do
+      before(:each) do
+        request.headers["accept"] = 'application/json'
+        request.headers["Content-Type"] = 'application/json'
+        request.headers["login"] = @user.login
+        request.headers["Authorization"] = 'AEsXr_Ec6R_trmAoLd5S'
       end
-      it "confirms current_work_unit & activity request have the same project associated" do
-        expect(@current_work_unit.project_id).to eq(@activity.project_id)
+      it "assigns the current work unit id to the new activity" do
+        post :create, @activity_request
+        expect(assigns(:activity).work_unit_id).to eq(@current_work_unit.id)
       end
       it "confirms current_work_unit and activity_different don't have to same project associated"do
-        expect(@current_work_unit.project_id).not_to eq(@activity_different.project_id)
+        post :create, @activity_different_request
+        expect(assigns(:activity).work_unit_id).to eq(nil)
       end
       it "confirms that work units that have a stop time aren't associated to the activity" do
-        p @activity.work_unit_id
-        p @activity_different.work_unit_id
-        expect(@activity.work_unit_id).not_to eq(@non_current_work_unit.project_id)
+        @activity_request[:activity][:user_id] = @user2.id
+        p @activity_request
+        post :create, @activity_request
+        expect(assigns(:activity).work_unit_id).to eq(nil)
+
       end
+    end
+
+    describe "make a new activity that is an orphan from work units, if not clocked in" do
+      it "checks to see if the user is clocked in" do
+        # expect(@user.clocked_in?).to be false
+      end
+
     end
   end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -3,9 +3,12 @@
   describe ActivitiesController do
 
     before(:each) do
-      @activity = FactoryGirl.create(:activity)
+      @base_time = Time.now.beginning_of_day-1.day+12.hours
       @user = FactoryGirl.create(:user)
       @project = FactoryGirl.create(:project)
+      #create activity and work_unit that both have the same project associated
+      @activity = FactoryGirl.create(:activity, :project => @project)
+      @current_work_unit = FactoryGirl.create(:work_unit, :project => @project, :start_time => @base_time, :stop_time => nil, :user => @user, :hours => nil, :notes => "Work Unit, Clocked in")
     end
 
     describe "hit endpoint with a post request that saves activity" do
@@ -29,5 +32,15 @@
             Activity.where(description: "UPDATE AUTH TEST").count
             }.from(0).to(1)
       end
+    end
+
+    describe "make a new activity that is associated with the current work unit, if clocked_in" do
+      it "checks to see if the user is clocked in" do
+        expect(@user.clocked_in?).to be true
+      end
+      it "confirms current_work_unit & activity request have the same project associated" do
+        expect(@current_work_unit.project_id).to eq(@activity.project_id)
+      end
+
     end
   end

--- a/spec/factories/activities_factory.rb
+++ b/spec/factories/activities_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     time Time.now
     project
     user
-    # work_unit_id nil
+    work_unit_id nil
     action "commit"
     description "New commit"
     properties {

--- a/spec/factories/activities_factory.rb
+++ b/spec/factories/activities_factory.rb
@@ -3,6 +3,8 @@ FactoryGirl.define do
     source "github"
     time Time.now
     project
+    user
+    # work_unit_id nil
     action "commit"
     description "New commit"
     properties {

--- a/spec/tasks/orphan_assocations_spec.rb
+++ b/spec/tasks/orphan_assocations_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+require 'orphan_activity_associator'
+
+describe OrphanActivityAssociator do
+  before :each do
+    Timecop.travel(Time.parse("6/2/2015 10am"))
+  end
+
+  let :earliest_time do
+    Time.now - 24.hours
+  end
+
+  subject :associator do
+    OrphanActivityAssociator.new(earliest_time)
+  end
+
+  after :each do
+    Timecop.return
+  end
+
+  #activity without work unit
+  #that is recent
+  #user associated with orphan activies:
+  #  clocked-in 15 after activity
+  #  OR
+  #  clocked-out 15 before
+  #same project as activity
+
+  let :project do
+    FactoryGirl.create(:project)
+  end
+
+  let :other_project do
+    FactoryGirl.create(:project)
+  end
+
+  let :start_time do
+    Time.now - 3.hours
+  end
+
+  let :stop_time do
+    Time.now - 2.hours
+  end
+
+  let :user do
+    FactoryGirl.create(:user)
+  end
+
+  let! :work_unit do
+    FactoryGirl.create(:work_unit,
+                       :user => user,
+                       :start_time => start_time,
+                       :stop_time => stop_time,
+                       :hours => 1.0,
+                       :project => project)
+  end
+
+  describe "should associate an orphan activity that" do
+    it "precedes a work unit with matching project by less than 15 minutes" do
+      activity = FactoryGirl.create(:activity, :time => start_time - 14.minutes, :project => project, :user => user)
+      associator.run
+      expect(activity.reload.work_unit_id).to eql(work_unit.id)
+    end
+
+    it "follows a work unit with matching project by less than 15 minutes" do
+      activity = FactoryGirl.create(:activity, :time => stop_time + 14.minutes, :project => project, :user => user)
+      associator.run
+      expect(activity.reload.work_unit_id).to eql(work_unit.id)
+    end
+  end
+
+  describe "older data" do
+    let :start_time do
+      Time.now - 2.days
+    end
+
+    let :stop_time do
+      Time.now - (2.days - 1.hour)
+    end
+
+    it "should not associate if the activity is too old" do
+      activity = FactoryGirl.create(:activity, :time => stop_time + 14.minutes, :project => project, :user => user)
+      associator.run
+      expect(activity.reload.work_unit_id).to be_nil
+    end
+  end
+
+  describe "should not associate an orphan activity" do
+    it "precedes a work unit with matching project by more than 15 minutes" do
+      activity = FactoryGirl.create(:activity, :time => start_time - 16.minutes, :project => project, :user => user)
+      associator.run
+      expect(activity.reload.work_unit_id).to be_nil
+    end
+
+    it "follows a work unit with matching project by more than 15 minutes" do
+      activity = FactoryGirl.create(:activity, :time => stop_time + 16.minutes, :project => project, :user => user)
+      associator.run
+      expect(activity.reload.work_unit_id).to be_nil
+    end
+
+    it "to work unit with different project" do
+      activity = FactoryGirl.create(:activity, :time => stop_time + 1.minutes, :project => other_project, :user => user)
+      associator.run
+      expect(activity.reload.work_unit_id).to be_nil
+    end
+  end
+
+  it "should not associate an associated activity" do
+    other_work_unit = FactoryGirl.create(:work_unit)
+    activity = FactoryGirl.create(:activity, :time => stop_time + 1.minutes, :project => other_project, :work_unit => other_work_unit)
+    associator.run
+    expect(activity.reload.work_unit_id).to eql(other_work_unit.id)
+  end
+
+  it "should not associate to the work units of a different user" do
+    other_user = FactoryGirl.create(:user)
+    activity = FactoryGirl.create(:activity, :time => stop_time + 1.minutes, :project => project, :user => other_user)
+    associator.run
+    expect(activity.reload.work_unit_id).to be_nil
+  end
+
+end


### PR DESCRIPTION
Of note: the associator makes no special preference of which of many eligible
work units to land an orphaned activity on. It might be better to e.g. chose
the closest or largest WU, but in the cases where there are several candidates,
distinguishing between them didn't seem very important