### PR TITLE
Delete annotations 107959772

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -35,6 +35,18 @@ class AnnotationsController < ApplicationController
     end
   end
 
+  #DELETE
+  def destroy
+    @annotation = Activity.find(params[:id])
+    if @annotation.work_unit
+      @work_unit = @annotation.work_unit
+    end
+    @annotation.destroy
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def activity_params

--- a/app/views/annotations/destroy.js.erb
+++ b/app/views/annotations/destroy.js.erb
@@ -1,0 +1,2 @@
+$('#recent_annotations').replaceWith("<%= escape_javascript(render :partial => 'shared/recent_annotations') %>")
+$('#wu_annotations').replaceWith("<%= escape_javascript(render :partial => 'shared/wu_annotations') %>")

--- a/app/views/shared/_annotations_narrow.haml
+++ b/app/views/shared/_annotations_narrow.haml
@@ -2,5 +2,7 @@
   - token = SecureRandom.hex(8)
   = content_tag(:tr, :id => token, :class => 'annotations') do
     %ul
-      %li= annotations.time
+      %li
+        = annotations.time
+        = link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'
       %li= annotations.description

--- a/app/views/shared/_timeclock.html.haml
+++ b/app/views/shared/_timeclock.html.haml
@@ -17,7 +17,7 @@
         = f.text_field :hours, :size => 15, :placeholder => "Hours"
       = f.button "Clock Out", :type => :submit, :id => 'clock_out_button'
 
-    = form_for(:activities, :url => add_annotation_path, :html => {:method => :create, :id => :annotation_form}) do |g|
+    = form_for(:activities, :url => annotations_path, :html => {:method => :create, :id => :annotation_form}) do |g|
       = g.text_area :description, :placeholder => "Annotations", :id => "annotation_input"
       = g.hidden_field :action, :value => "Annotation"
       = g.hidden_field :source, :value => "User"

--- a/app/views/work_units/edit.html.haml
+++ b/app/views/work_units/edit.html.haml
@@ -7,7 +7,7 @@
 
 = render :partial => "shared/wu_annotations"
 
-= form_for(:activities, :url => add_annotation_path, :html => {:method => :create, :id => :wu_annotation_form}) do |g|
+= form_for(:activities, :url => annotations_path, :html => {:method => :create, :id => :wu_annotation_form}) do |g|
   = g.text_area :description, :placeholder => "Annotations", :id => "wu_annotation_input"
   = g.hidden_field :action, :value => "Annotation"
   = g.hidden_field :source, :value => "User"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ TimePulse::Application.routes.draw do
 
   resources :project_reports
   resources :invoice_reports, :only => :show
+  resources :annotations, :only => [:create, :destroy]
 
   resource :github, :only => [:create], :controller => 'github'
   resource :pivotal, :only => [:create], :controller => 'pivotal'
@@ -45,7 +46,7 @@ TimePulse::Application.routes.draw do
   match '/set_current_project/:id' => 'current_project#create', :as => :set_current_project, :via => :post
   match '/clock_in_on/:id' => 'clock_time#create', :as => :clock_in, :via => :post
   match '/clock_out' => 'clock_time#destroy', :as => :clock_out, :via => :delete
-  match '/add_annotation' => 'annotations#create', :as => :add_annotation, :via => :post
+  # match '/add_annotation' => 'annotations#create', :as => :add_annotation, :via => :post
 
   root :to => 'home#index'
 

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -1,12 +1,18 @@
 require 'spec_helper'
 
 describe AnnotationsController do
-    # let! :work_unit do FactoryGirl.create(:work_unit) end
-    # let! :annotation do FactoryGirl.create(:activity) end
+  let! :annotation do
+    FactoryGirl.create(:activity)
+  end
 
   describe "for an unlogged in user" do
     it "cannot create new annotation" do
       post :create
+      verify_authorization_unsuccessful
+    end
+
+    it "cannot delete an annotation" do
+      delete :destroy, id: annotation.id
       verify_authorization_unsuccessful
     end
   end
@@ -20,106 +26,123 @@ describe AnnotationsController do
       sign_in user
     end
 
-    let :valid_params do
-      {description: "A Description",
-        work_unit_id: work_unit_id,
-        project_id: project_id,
-        source: "User",
-        action: "Annotation",
-        user_id: user.id,
-        }
-    end
-
-    describe "with a work unit in params (not in progress)" do
-      let :work_unit do
-        FactoryGirl.create(:work_unit)
-      end
-      let :work_unit_id do
-        work_unit.id.to_s
-      end
-      let :project_id do
-        work_unit.project.id.to_s
+    describe "#create" do
+      let :valid_params do
+        {description: "A Description",
+          work_unit_id: work_unit_id,
+          project_id: project_id,
+          source: "User",
+          action: "Annotation",
+          user_id: user.id,
+          }
       end
 
-      it "creates a new annotation" do
-        lambda do
-          post :create, activities: valid_params, format: "js"
-        end.should change(Activity, :count).by(1)
-      end
-
-      it "associates the annotation with the given work unit" do
-        post :create, activities: valid_params, format: "js"
-
-        expect(work_unit.activities.last).
-          to eq(Activity.last)
-      end
-
-      it "gives the new annotation the same time as the work unit's stop time" do
-        post :create, activities: valid_params, format: "js"
-
-        expect(work_unit.activities.last).
-          to eq(Activity.last)
-      end
-    end
-
-    describe "without a work unit in params" do
-      let :work_unit_id do
-        ""
-      end
-
-      describe "with a current work unit" do
-        let :current_work_unit do
-          FactoryGirl.create(:in_progress_work_unit, user: user)
+      describe "with a work unit in params (not in progress)" do
+        let :work_unit do
+          FactoryGirl.create(:work_unit)
+        end
+        let :work_unit_id do
+          work_unit.id.to_s
         end
         let :project_id do
-          current_work_unit.project.id.to_s
+          work_unit.project.id.to_s
         end
 
-        it "creates a new activity" do
+        it "creates a new annotation" do
           lambda do
             post :create, activities: valid_params, format: "js"
           end.should change(Activity, :count).by(1)
         end
 
-        it "associates the new activity with the current work unit" do
+        it "associates the annotation with the given work unit" do
           post :create, activities: valid_params, format: "js"
 
-          expect(current_work_unit.activities.last).
+          expect(work_unit.activities.last).
             to eq(Activity.last)
         end
 
-        # Unsure how to properly test setting time to "now"
-        it "sets the activity's time" do
+        it "gives the new annotation the same time as the work unit's stop time" do
           post :create, activities: valid_params, format: "js"
 
-          expect(Activity.last.time).to_not be_nil
+          expect(work_unit.activities.last).
+            to eq(Activity.last)
         end
       end
 
-      describe "without a current work unit" do
-        let :project_id do
-          FactoryGirl.create(:project).id
+      describe "without a work unit in params" do
+        let :work_unit_id do
+          ""
         end
 
-        it "creates a new activity" do
-          lambda do
+        describe "with a current work unit" do
+          let :current_work_unit do
+            FactoryGirl.create(:in_progress_work_unit, user: user)
+          end
+          let :project_id do
+            current_work_unit.project.id.to_s
+          end
+
+          it "creates a new activity" do
+            lambda do
+              post :create, activities: valid_params, format: "js"
+            end.should change(Activity, :count).by(1)
+          end
+
+          it "associates the new activity with the current work unit" do
             post :create, activities: valid_params, format: "js"
-          end.should change(Activity, :count).by(1)
+
+            expect(current_work_unit.activities.last).
+              to eq(Activity.last)
+          end
+
+          # Unsure how to properly test setting time to "now"
+          it "sets the activity's time" do
+            post :create, activities: valid_params, format: "js"
+
+            expect(Activity.last.time).to_not be_nil
+          end
         end
 
-        it "does not associate the new activity with a work unit" do
-          post :create, activities: valid_params, format: "js"
+        describe "without a current work unit" do
+          let :project_id do
+            FactoryGirl.create(:project).id
+          end
 
-          expect(Activity.last.work_unit).to be_nil
+          it "creates a new activity" do
+            lambda do
+              post :create, activities: valid_params, format: "js"
+            end.should change(Activity, :count).by(1)
+          end
+
+          it "does not associate the new activity with a work unit" do
+            post :create, activities: valid_params, format: "js"
+
+            expect(Activity.last.work_unit).to be_nil
+          end
+
+          it "does not set a time" do
+            post :create, activities: valid_params, format: "js"
+
+            expect(Activity.last.time.blank?).to eq(true)
+          end
+
         end
-
-        it "does not set a time" do
-          post :create, activities: valid_params, format: "js"
-
-          expect(Activity.last.time.blank?).to eq(true)
-        end
-
       end
+    end
+
+    describe "#destroy" do
+
+      it "deletes the annotation from the database" do
+        expect do
+          delete :destroy, id: annotation.id, format: "js"
+        end.to change(Activity, :count).by(-1)
+      end
+
+      it "makes the activity unfindable in the database" do
+        delete :destroy, id: annotation.id, format: "js"
+        expect {Activity.find(annotation.id)}.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
     end
   end
 end

--- a/spec/stories/edit_work_units_without_minutes_rounding_error_spec.rb
+++ b/spec/stories/edit_work_units_without_minutes_rounding_error_spec.rb
@@ -39,6 +39,13 @@ steps "Minute truncation", :type => :feature do
     page.should have_content("This is another annotation!")
   end
 
+  it "should allow deletion of annotations" do
+    expect do
+      click_link("Delete", match: :first)
+      page.should_not have_content("This is another annotation!")
+    end.to change(Activity, :count).by(-1)
+  end
+
   it "should not cause errors in the edit view" do
     click_button("Submit")
     page.should_not have_content("Hours must not be greater than the difference between start and stop times")


### PR DESCRIPTION
Adds a delete link to activities on the home page and work-unit edit page.

This pull request includes #173 and #174 