### PR TITLE
Reformat recent annotations block.

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -105,6 +105,17 @@ Ninja.behavior({
         $details.toggle();
       }
     },
+
+    '.recent_annotation_label': {
+      click: function(evnt, elem) {
+        var $label = $(elem);
+        var $details = $label.parents('tbody').find('#details-'+$label.parents('tr')[0].id);
+        console.log($details);
+        $label.toggleClass('open');
+        $details.toggle();
+      }
+    },
+
     'form#wu_annotation_form':    Ninja.submitsAsAjax({
         busyElement: function(elem){ return $('#wu_annotations')}
       }),

--- a/app/assets/stylesheets/partials/recent_annotations.sass
+++ b/app/assets/stylesheets/partials/recent_annotations.sass
@@ -1,0 +1,42 @@
+@import constants
+
+#recent_annotations table.listing
+  table-layout: auto
+  .recent_annotation_details
+    display: none
+    border-bottom: 1px dotted $primary_light_2
+
+  .recent_annotation_label
+    cursor: pointer
+    line-height: 1
+    &::before
+      content: ''
+      display: inline-block
+      width: 0
+      height: 0
+      margin: 0 .25rem 3px 0
+      border: 6px solid gray
+      border-color: white white white gray
+      border-width: 5px 0 5px 10px
+      font-size: 0px
+      vertical-align: middle
+    &.open::before
+      margin-bottom: 0
+      border-color: gray white white white
+      border-width: 10px 5px 0 5px
+      vertical-align: baseline
+
+  dl
+    +clearfix
+    margin: 0
+    padding: 0 0 1ex 1rem
+    font-size: .8em
+    font-weight: bold
+  dt, dd
+    float: left
+    margin: 0
+  dt
+    clear: left
+    width: 25%
+  dd
+    width: 75%

--- a/app/helpers/annotations_helper.rb
+++ b/app/helpers/annotations_helper.rb
@@ -1,0 +1,21 @@
+module AnnotationsHelper
+  include ProjectsHelper
+
+  def recent_annotation_row_tag(annotations, token = nil, cssclass = nil, &block)
+    content_tag(:tr,
+                 :id => token,
+                 :class => ['annotations', cssclass ]
+                ) do
+      yield
+    end
+  end
+
+  def recent_annotation_details_row_tag(token = nil, cssclass = nil, &block)
+      content_tag(:tr,
+                   :id => "details-#{token}",
+                   :class => ['recent_annotation_details', cssclass ]
+                  ) do
+      yield
+    end
+  end
+end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,13 +1,13 @@
 - set_headline "TIMECLOCK"
 = render :partial => "shared/timeclock"
 = render :partial => 'home/work_unit_form'
-= render :partial => "shared/recent_annotations"
 = render :partial => 'home/current_project_block'
 
 
 -content_for :aux do
   = render :partial => "shared/week_summary", :locals => { :this_week_units => current_user.work_units.this_week }
   = render :partial => "shared/recent_work"
+  = render :partial => "shared/recent_annotations"
   = render :partial => "shared/recent_commits"
   = render :partial => "shared/recent_pivotal_updates"
 

--- a/app/views/shared/_annotations_narrow.haml
+++ b/app/views/shared/_annotations_narrow.haml
@@ -1,8 +1,17 @@
 - cache("annotations_narrow_#{annotations.id}", :skip_digest => true) do
   - token = SecureRandom.hex(8)
-  = content_tag(:tr, :id => token, :class => 'annotations') do
-    %ul
-      %li
-        = annotations.time
-        = link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'
-      %li= annotations.description
+  = recent_annotation_row_tag(annotations, token, :narrow) do
+    %td
+      %span.recent_annotation_label.nobr= (((annotations.description).split(' '))[0, 4]).join(' ')
+    %td
+      = annotations.time.strftime("%m/%d/%Y %H:%M") if annotations.time
+    %td.tools.nobr
+      = link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'
+  = recent_annotation_details_row_tag(token, :hidden) do
+    %td{ colspan: 3 }
+      %dl
+        %dt Annotation:
+        %dd= annotations.description
+
+        %dt Project:
+        %dd= annotations.project.client.name + ': ' + annotations.project.name

--- a/app/views/shared/_recent_annotations.html.haml
+++ b/app/views/shared/_recent_annotations.html.haml
@@ -1,3 +1,9 @@
 = page_block("Recent Annotations", :id => "recent_annotations") do
-  %tbody
-    = render :partial => "shared/annotations_narrow", :collection => current_user.reload.activities.last(10), :as => :annotations
+  %table.listing
+    %thead
+      %tr
+        %th Annotation
+        %th Time
+        %th
+    %tbody
+      = render :partial => "shared/annotations_narrow", :collection => current_user.reload.activities.last(8), :as => :annotations

--- a/app/views/shared/_wu_annotations.html.haml
+++ b/app/views/shared/_wu_annotations.html.haml
@@ -1,3 +1,9 @@
 = page_block("Annotations", :id => "wu_annotations") do
-  %tbody
-    = render :partial => "shared/annotations_narrow", :collection => @work_unit.activities, :as => :annotations
+  %table.listing
+    %thead
+      %tr
+        %th Annotation
+        %th Time
+        %th
+    %tbody
+      = render :partial => "shared/wu_annotations_narrow", :collection => @work_unit.activities, :as => :annotations

--- a/app/views/shared/_wu_annotations_narrow.haml
+++ b/app/views/shared/_wu_annotations_narrow.haml
@@ -1,0 +1,7 @@
+- cache("wu_annotations_narrow_#{annotations.id}", :skip_digest => true) do
+  - token = SecureRandom.hex(8)
+  = content_tag(:tr, :id => token, :class => 'annotations') do
+    %tr
+      %td= annotations.description
+      %td= annotations.time
+      %td.tools.nobr= link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'

--- a/spec/helpers/annotations_helper_spec.rb
+++ b/spec/helpers/annotations_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe AnnotationsHelper do
+
+  #Delete this example and add some real ones or delete this file
+  it "should be included in the object returned by #helper" do
+    included_modules = (class << helper; self; end).send :included_modules
+    included_modules.should include(AnnotationsHelper)
+  end
+
+end

--- a/spec/stories/clock_in_clock_out_spec.rb
+++ b/spec/stories/clock_in_clock_out_spec.rb
@@ -67,7 +67,7 @@ steps "clock in and out on projects", :type => :feature do
 
   it "should show newly-created annotation under Recent Annotations" do
     within("#recent_annotations") do
-      page.should have_content("Starting work on project #1!")
+      page.should have_content("Starting work on project")
     end
   end
 
@@ -80,7 +80,7 @@ steps "clock in and out on projects", :type => :feature do
 
   it "should show newly-created annotation under Recent Annotations" do
     within("#recent_annotations") do
-      page.should have_content("Did a little work on project #1")
+      page.should have_content("Did a little work")
     end
   end
 
@@ -144,7 +144,7 @@ steps "clock in and out on projects", :type => :feature do
 
   it "should show newly-created annotation under Recent Annotations" do
     within("#recent_annotations") do
-      page.should have_content("I worked all day on this")
+      page.should have_content("I worked all day")
     end
   end
 


### PR DESCRIPTION
* Moved "recent annotations" to right column.
* Formatted datetime to human-readable string (Month, Day, Year, Hour, Minute)
* Converted bulleted list to table so format/styling matches other right-column blocks; long annotation descriptions are expandable and titles of recent annotations are limited to four words
* Limited to eight recent annotations, as in recent work units