### PR TITLE
Fix datetime picker for homepage #109198462

### DIFF
--- a/app/views/home/_work_unit_form.html.haml
+++ b/app/views/home/_work_unit_form.html.haml
@@ -5,7 +5,7 @@
       Hours are not forced to the difference between start and stop: you may enter "I worked 2 hours
       between 9am and 1pm", for example.  If hours are left blank, they will be computed as
       the difference between start and stop time.
-    = form_for(new_work_unit_for_current_project, :html => {:class => "ajax-form"}) do |f|
+    = form_for(new_work_unit_for_current_project, :namespace => "manual", :html => {:class => "ajax-form"}) do |f|
       = f.error_messages
       = f.hidden_field  :calculate, :value => true
 

--- a/app/views/work_units/create.js.erb
+++ b/app/views/work_units/create.js.erb
@@ -1,7 +1,5 @@
 $('#current_project').replaceWith("<%= escape_javascript(render :partial => 'home/current_project_block')  %>")
 $('#work_unit_form').replaceWith("<%= escape_javascript(render :partial => 'home/work_unit_form')  %>")
-
-
 $('#recent_work').replaceWith("<%= escape_javascript(render :partial => 'shared/recent_work') %>")
 $('#this_week').replaceWith("<%= escape_javascript(render :partial => 'shared/week_summary', :locals => { :this_week_units => current_user.work_units.this_week }) %>")
 $('#recent_annotations').replaceWith("<%= escape_javascript(render :partial => 'shared/recent_annotations') %>")

--- a/app/views/work_units/create.js.erb
+++ b/app/views/work_units/create.js.erb
@@ -1,4 +1,7 @@
 $('#current_project').replaceWith("<%= escape_javascript(render :partial => 'home/current_project_block')  %>")
+$('#work_unit_form').replaceWith("<%= escape_javascript(render :partial => 'home/work_unit_form')  %>")
+
+
 $('#recent_work').replaceWith("<%= escape_javascript(render :partial => 'shared/recent_work') %>")
 $('#this_week').replaceWith("<%= escape_javascript(render :partial => 'shared/week_summary', :locals => { :this_week_units => current_user.work_units.this_week }) %>")
 $('#recent_annotations').replaceWith("<%= escape_javascript(render :partial => 'shared/recent_annotations') %>")

--- a/spec/stories/enter_work_units_manually_spec.rb
+++ b/spec/stories/enter_work_units_manually_spec.rb
@@ -48,7 +48,7 @@ steps "User manually enters work units", :type => :feature do
 
   it "should pre-check the billable box" do
     within "#work_unit_form" do
-      page.should have_checked_field( 'work_unit_billable' )
+      page.should have_checked_field( 'manual_work_unit_billable' )
     end
   end
 
@@ -103,13 +103,13 @@ steps "User manually enters work units", :type => :feature do
 
   it "should pre-check the billable box for the next work unit" do
     within "#work_unit_form" do
-      page.should have_checked_field( 'work_unit_billable' )
+      page.should have_checked_field( 'manual_work_unit_billable' )
     end
   end
 
   it "when I fill in valid work unit information" do
-    within "#new_work_unit" do
-      find('#work_unit_billable').set(false)
+    within "#manual_new_work_unit" do
+      find('#manual_work_unit_billable').set(false)
     end
     fill_in "Start time", :with => (@start_time = (Time.zone.now - 2.hours)).to_s(:short_datetime)
     fill_in "Stop time", :with => (@stop_time = Time.zone.now).to_s(:short_datetime)
@@ -149,13 +149,13 @@ steps "User manually enters work units", :type => :feature do
 
   it "should not pre-check the billable box" do
     within "#work_unit_form" do
-      page.should_not have_checked_field('#work_unit_billable')
+      page.should_not have_checked_field('#manual_work_unit_billable')
     end
   end
 
   it "when I fill in valid work unit information" do
     within "#work_unit_form" do
-      find('#work_unit_billable').set(true)
+      find('#manual_work_unit_billable').set(true)
     end
     fill_in "Start time", :with => (@start_time = (Time.zone.now - 3.hours)).to_s(:short_datetime)
     fill_in "Stop time", :with => (@stop_time = Time.zone.now).to_s(:short_datetime)
@@ -175,7 +175,7 @@ steps "User manually enters work units", :type => :feature do
 
   it "should not pre-check the billable box" do
     within "#work_unit_form" do
-      page.should have_unchecked_field( 'work_unit_billable' )
+      page.should have_unchecked_field( 'manual_work_unit_billable' )
     end
   end
 
@@ -208,7 +208,7 @@ steps "User manually enters work units", :type => :feature do
 
   it "should not display input fields in manual time entry for non-clockable project" do
     page.should have_content("This is not a clockable project.")
-    page.should_not have_field('work_unit_start_time')
+    page.should_not have_field('manual_work_unit_start_time')
   end
 
 end

--- a/spec/stories/switch_project_spec.rb
+++ b/spec/stories/switch_project_spec.rb
@@ -42,17 +42,17 @@ steps "log in and switch projects", :type => :feature do
   it "should have a work unit form (XPath Gem format)" do
     within "#work_unit_form" do
       page.should have_xpath(XPath.generate do |doc|
-         doc.descendant(:form)[doc.attr(:id) == "new_work_unit"][doc.attr(:action) == '/work_units']
+         doc.descendant(:form)[doc.attr(:id) == "manual_new_work_unit"][doc.attr(:action) == '/work_units']
       end)
     end
   end
 
   it "should have a work unit form (Plain XPath format)" do
-    page.should have_xpath("//form[@id='new_work_unit'][@action='/work_units']")
+    page.should have_xpath("//form[@id='manual_new_work_unit'][@action='/work_units']")
   end
 
   it "should have a work unit form (have_selector format)" do
-    page.should have_selector("form#new_work_unit[action='/work_units']")
+    page.should have_selector("form#manual_new_work_unit[action='/work_units']")
   end
 
 

--- a/spec/views/home/index.html_spec.rb
+++ b/spec/views/home/index.html_spec.rb
@@ -24,7 +24,7 @@ describe "/home/index" do
     end
     it "should have a work unit form" do
       render
-      rendered.should have_selector("form#new_work_unit[action='/work_units']")
+      rendered.should have_selector("form#manual_new_work_unit[action='/work_units']")
     end
     it "should have a 'Save Changes' submit button" do
       render


### PR DESCRIPTION
Add a namespace to manual work-unit form to distinguish from the timeclock work-unit form. Also fixed the ajax command to recreate the work-unit form after submit.