### PR TITLE
Reformat recent annotations tbl 109215572

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,10 @@ class User < ActiveRecord::Base
     work_units.completed.recent.includes(:project => :client)
   end
 
+  def recent_activities
+    activities.recent.includes(:project => :client)
+  end
+
   def recent_commits
 
     activities.git_commits.recent.includes(:project => :client)

--- a/app/views/shared/_annotations_narrow.haml
+++ b/app/views/shared/_annotations_narrow.haml
@@ -14,4 +14,4 @@
         %dd= annotations.description
 
         %dt Project:
-        %dd= annotations.project.client.name + ': ' + annotations.project.name
+        %dd= annotations.project.client.name + '- ' + annotations.project.name

--- a/app/views/shared/_recent_annotations.html.haml
+++ b/app/views/shared/_recent_annotations.html.haml
@@ -6,4 +6,4 @@
         %th Time
         %th
     %tbody
-      = render :partial => "shared/annotations_narrow", :collection => current_user.reload.activities.last(8), :as => :annotations
+      = render :partial => "shared/annotations_narrow", :collection => current_user.reload.recent_activities, :as => :annotations

--- a/app/views/shared/_wu_annotations.html.haml
+++ b/app/views/shared/_wu_annotations.html.haml
@@ -6,4 +6,4 @@
         %th Time
         %th
     %tbody
-      = render :partial => "shared/wu_annotations_narrow", :collection => @work_unit.activities, :as => :annotations
+      = render :partial => "shared/wu_annotations_edit_narrow", :collection => @work_unit.activities, :as => :annotations

--- a/app/views/shared/_wu_annotations_edit_narrow.haml
+++ b/app/views/shared/_wu_annotations_edit_narrow.haml
@@ -1,0 +1,7 @@
+- cache("wu_annotations_narrow_#{annotations.id}", :skip_digest => true) do
+  - token = SecureRandom.hex(8)
+  = content_tag(:tr, :id => token, :class => 'annotations') do
+    %tr
+      %td= annotations.description
+      %td= ((annotations.time).to_s)[0, 19]
+      %td.tools.nobr= link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'

--- a/app/views/shared/_wu_annotations_narrow.haml
+++ b/app/views/shared/_wu_annotations_narrow.haml
@@ -1,7 +1,6 @@
-- cache("wu_annotations_narrow_#{annotations.id}", :skip_digest => true) do
+- cache("annotations_narrow_#{annotations.id}", :skip_digest => true) do
   - token = SecureRandom.hex(8)
-  = content_tag(:tr, :id => token, :class => 'annotations') do
-    %tr
-      %td= annotations.description
-      %td= ((annotations.time).to_s)[0, 19]
-      %td.tools.nobr= link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'
+  = recent_annotation_row_tag(annotations, token, :narrow) do
+    %td= annotations.description
+    %td= ((annotations.time).to_s)[0, 19]
+    %td= annotations.project.client.name + ': ' + annotations.project.name

--- a/app/views/shared/_wu_annotations_narrow.haml
+++ b/app/views/shared/_wu_annotations_narrow.haml
@@ -3,5 +3,5 @@
   = content_tag(:tr, :id => token, :class => 'annotations') do
     %tr
       %td= annotations.description
-      %td= annotations.time
+      %td= ((annotations.time).to_s)[0, 19]
       %td.tools.nobr= link_to 'Delete', annotation_path(annotations, :delete_id => token), :method => :delete, data: { confirm: "Are you sure?" }, class: 'actions delete'

--- a/app/views/work_units/show.html.haml
+++ b/app/views/work_units/show.html.haml
@@ -1,5 +1,7 @@
 - set_headline ""
 
+/ headline, e.g. 'Showing Work Unit Details', obscures Capybara clicking on Edit button
+
 .button-wrap
   = link_to 'Edit', edit_work_unit_path(@work_unit), class: 'button radius'
 
@@ -31,6 +33,13 @@
   %b Billed:
   =h @work_unit.billed?
 
+
 = page_block("Annotations", :id => "wu_annotations") do
-  %tbody
-    = render :partial => "shared/annotations_narrow", :collection => @work_unit.activities, :as => :annotations
+  %table.listing
+    %thead
+      %tr
+        %th Annotation
+        %th Time
+        %th Project
+    %tbody
+      = render :partial => "shared/wu_annotations_narrow", :collection => @work_unit.activities, :as => :annotations


### PR DESCRIPTION
* Fixed formatting for annotations tables on homepage and work unit show page
* Re-ordered recent annotations table so most recent annotation is listed first